### PR TITLE
Fix invalid stack name + minor fixes

### DIFF
--- a/cloudformation-openvidu-demos/README.md
+++ b/cloudformation-openvidu-demos/README.md
@@ -7,66 +7,66 @@ This repository is intended to be a point where the user can deploy OpenVidu Dem
 ### [OpenVidu Web Page](http://openvidu.io/)
 
 ## Different scenarios:
-- __Turn and Self signed certificate__
-- __Turn and Let's Encrypt certificate__
+- __TURN and self-signed certificate__
+- __TURN and Let's Encrypt certificate__
 
 ## Common steps
 
 Independent of the scenario of your choice, there are some steps you should do in advance.
 
-1. You definetly need an amazon' **AWS account**. If you don't have one go to [AWS website](https://www.amazon.com/ap/signin)
+1. You definetly need an Amazon **AWS account**. If you don't have one go to [AWS website](https://www.amazon.com/ap/signin)
 
-2. Then, you can log into your account to go to **Cloud Formation** tab. Find it in **AWS Dashboard** under **Management tools**.
+2. Then, log into your account and open the **CloudFormation** service. Find it in **AWS Dashboard** under **All services** > **Management Tools**.
 
-3. Next, you see the **Cloud Formation** Dashboard where you have to press *Create Stack*.
+3. Next, you see the **CloudFormation** Dashboard where you have to press *Create new stack*.
 
-4. Once there, you must upload [this](https://github.com/OpenVidu/openvidu-cloud-devops/blob/master/cloudformation-openvidu-demos/CF-OpenVidu-Demos-NoSignal.json) file we provide and press Next.
+4. Once there, you must upload [this file](https://github.com/OpenVidu/openvidu-cloud-devops/blob/master/cloudformation-openvidu-demos/CF-OpenVidu-Demos-NoSignal.json) we provide and press Next.
 
-## Turn and Self signed certificate
+## TURN and self-signed certificate
 
 1. Now, you should see a list of Parameters.
 
-2. The first one is the *Stack Name*. Feel free to be as original as you want but we recomend __OpenVidu_Demos__ and we use this name throughout the docs.
+2. The first one is the *Stack name*. Feel free to be as original as you want but we recomend __OpenVidu-Demos__ as we use this name throughout the docs.
 
-3. In this scenario you don't need to complete the *Let's Encrypt Configuration (Optional) Configuration* section.
+3. In this scenario you don't need to complete the section *Let's Encrypt Configuration (Optional)*.
 
-4. Focus on the *Other parameters* 
+4. Focus on the section *Other parameters*:
 
-    1. Choose an *Instance Type*. We recommended __t2.medium__ at least.
+    1. Choose an *Instance Type*. We recommend __t2.medium__ at least.
 
     2. Choose an existing *Key Name* in order to access the instance once it is built.
 
 6. Press Next to continue.
 
-7. The next screen gives you the chance to specify some __keys__ and other options. We are not using this screen right now. So you can press Next.
+7. The next screen gives you the chance to specify some __keys__ and other options. We are not using this screen right now, so you can press Next.
 
-8. You can now review all the parameters you've introduced before. If everything looks great press Create.
+8. You can now review all the parameters you've introduced before. If everything looks great, press Create.
 
-9. You will see the *Stack* in *CREATE_IN_PROGRESS* state.
+9. You will see the *Stack* in *CREATE_IN_PROGRESS* status.
 
-10. It takes about 7 to 10 minutes to deploy the Demo Software, so, please be patient. Once the deployment is ready you should be able to access the Demos throught the URL you can find under *Outputs* tab.
+10. It takes about 7 to 10 minutes to deploy the Demo Software, so please be patient. Once the deployment is ready you should be able to access the Demos throught the URL you can find under the *Outputs* tab.
 
 11. And that's it. Enjoy!
 
-## Turn and Let's Encrypt certificate
+## TURN and Let's Encrypt certificate
 
 **IMPORTANT**: You must allocate an *Elastic IP* and register on a valid DNS provider in order to use Let's Encrypt.
 
 1. Now, you should see a list of Parameters.
 
-2. The first one is the *Stack Name*. Feel free to be as original as you want but we recomend __OpenVidu_Demos__ and we use this name throughout the docs.
+2. The first one is the *Stack name*. Feel free to be as original as you want but we recomend __OpenVidu-Demos__ as we use this name throughout the docs.
 
-3. In the *SLet's Encrypt Configuration (Optional) Configuration* section we are going set up the information for Let's Encrypt.
+3. In the section *Let's Encrypt Configuration (Optional)* we are going set up the information for Let's Encrypt:
 
     1. First of all, choose to use a Let's Encrypt Certificate from the drop-down menu.
 
     2. Enter your email address.
 
-    3. Enter the Fully qualified domain name you've registered in your DNS provider.
+    3. Enter the Fully Qualified Domain Name you've registered with your DNS provider.
 
     4. Enter the Elastic IP address you've allocated.
 
-4. Check now *Other parameters* 
+4. Check now *Other parameters*:
 
     1. Choose an *Instance Type*. We recommended __t2.medium__ at least.
 
@@ -74,13 +74,13 @@ Independent of the scenario of your choice, there are some steps you should do i
 
 6. Press Next to continue.
 
-7. The next screen gives you the chance to specify some __keys__ and other options. We are not using this screen right now. So you can press Next.
+7. The next screen gives you the chance to specify some __keys__ and other options. We are not using this screen right now, so you can press Next.
 
-8. You can now review all the parameters you've introduced before. If everything looks great press Create.
+8. You can now review all the parameters you've introduced before. If everything looks great, press Create.
 
-9. You will see the *Stack* in *CREATE_IN_PROGRESS* state.
+9. You will see the *Stack* in *CREATE_IN_PROGRESS* status.
 
-10. It takes about 7 to 10 minutes to deploy the Demo Software, so, please be patient. Once the deployment is ready you should be able to access the Demos throught the URL you can find under *Outputs* tab.
+10. It takes about 7 to 10 minutes to deploy the Demo Software, so please be patient. Once the deployment is ready you should be able to access the Demos throught the URL you can find under the *Outputs* tab.
 
 11. And that's it. Enjoy!
 

--- a/cloudformation-openvidu-demos/README.md
+++ b/cloudformation-openvidu-demos/README.md
@@ -30,11 +30,11 @@ Independent of the scenario of your choice, there are some steps you should do i
 
 3. In this scenario you don't need to complete the section *Let's Encrypt Configuration (Optional)*.
 
-4. Focus on the section *Other parameters*:
+4. In the section *Other parameters*:
 
-    1. Choose an *Instance Type*. We recommend __t2.medium__ at least.
+    1. Choose an value for *InstanceType*. We recommend __t2.medium__ at least.
 
-    2. Choose an existing *Key Name* in order to access the instance once it is built.
+    2. Choose a value for *KeyName*. It must be the name of an existing EC2 Key Pair, used later to access the instance through SSH. If you haven't already created an EC2 Key Pair, [check the documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) and create or import a new key.
 
 6. Press Next to continue.
 
@@ -66,11 +66,11 @@ Independent of the scenario of your choice, there are some steps you should do i
 
     4. Enter the Elastic IP address you've allocated.
 
-4. Check now *Other parameters*:
+4. In the section *Other parameters*:
 
-    1. Choose an *Instance Type*. We recommended __t2.medium__ at least.
+    1. Choose an value for *InstanceType*. We recommend __t2.medium__ at least.
 
-    2. Choose an existing *Key Name* in order to access the instance once it is built.
+    2. Choose a value for *KeyName*. It must be the name of an existing EC2 Key Pair, used later to access the instance through SSH. If you haven't already created an EC2 Key Pair, [check the documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) and create or import a new key.
 
 6. Press Next to continue.
 

--- a/cloudformation-openvidu-demos/README.md
+++ b/cloudformation-openvidu-demos/README.md
@@ -36,17 +36,17 @@ Independent of the scenario of your choice, there are some steps you should do i
 
     2. Choose a value for *KeyName*. It must be the name of an existing EC2 Key Pair, used later to access the instance through SSH. If you haven't already created an EC2 Key Pair, [check the documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) and create or import a new key.
 
-6. Press Next to continue.
+5. Press Next to continue.
 
-7. The next screen gives you the chance to specify some __keys__ and other options. We are not using this screen right now, so you can press Next.
+6. The next screen gives you the chance to specify some __keys__ and other options. We are not using this screen right now, so you can press Next.
 
-8. You can now review all the parameters you've introduced before. If everything looks great, press Create.
+7. You can now review all the parameters you've introduced before. If everything looks great, press Create.
 
-9. You will see the *Stack* in *CREATE_IN_PROGRESS* status.
+8. You will see the *Stack* in *CREATE_IN_PROGRESS* status.
 
-10. It takes about 7 to 10 minutes to deploy the Demo Software, so please be patient. Once the deployment is ready you should be able to access the Demos throught the URL you can find under the *Outputs* tab.
+9. It takes about 7 to 10 minutes to deploy the Demo Software, so please be patient. Once the deployment is ready you should be able to access the Demos throught the URL you can find under the *Outputs* tab.
 
-11. And that's it. Enjoy!
+10. And that's it. Enjoy!
 
 ## TURN and Let's Encrypt certificate
 
@@ -72,17 +72,17 @@ Independent of the scenario of your choice, there are some steps you should do i
 
     2. Choose a value for *KeyName*. It must be the name of an existing EC2 Key Pair, used later to access the instance through SSH. If you haven't already created an EC2 Key Pair, [check the documentation](http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-key-pairs.html) and create or import a new key.
 
-6. Press Next to continue.
+5. Press Next to continue.
 
-7. The next screen gives you the chance to specify some __keys__ and other options. We are not using this screen right now, so you can press Next.
+6. The next screen gives you the chance to specify some __keys__ and other options. We are not using this screen right now, so you can press Next.
 
-8. You can now review all the parameters you've introduced before. If everything looks great, press Create.
+7. You can now review all the parameters you've introduced before. If everything looks great, press Create.
 
-9. You will see the *Stack* in *CREATE_IN_PROGRESS* status.
+8. You will see the *Stack* in *CREATE_IN_PROGRESS* status.
 
-10. It takes about 7 to 10 minutes to deploy the Demo Software, so please be patient. Once the deployment is ready you should be able to access the Demos throught the URL you can find under the *Outputs* tab.
+9. It takes about 7 to 10 minutes to deploy the Demo Software, so please be patient. Once the deployment is ready you should be able to access the Demos throught the URL you can find under the *Outputs* tab.
 
-11. And that's it. Enjoy!
+10. And that's it. Enjoy!
 
 **IMPORTANT**: Despite saying *CREATE_COMPLETE* it can take a bit longer to finish the deployment. Please be patient.
 


### PR DESCRIPTION
"OpenVidu_Demos" is an invalid name because AWS doesn't accept "_" in the name. It only accepts letters, numbers and "-". If all docs really use "OpenVidu_Demos", then I suggest updating all of them to "OpenVidu-Demos".
TURN is better written in upper case as it is an acronym ("Traversal Using Relays around NAT") and it is commonly written that way in online documentation.
The rest of the changes are minor corrections to match the instructions closely with the AWS website.